### PR TITLE
optimized kingsmessage apis and add adminonly to kingsmessage page

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -20,7 +20,7 @@ class API {
   }
 
   static async readKingsMessage() {
-    const $API_PATH = "/kingsMessage";
+    const $API_PATH = "/readKingsMessage";
     const $API_URL = $BASE_URL + $API_PATH;
     try {
       const {

--- a/client/src/middlewares/fetcher.js
+++ b/client/src/middlewares/fetcher.js
@@ -5,7 +5,7 @@
  * @returns {object, object}
  */
 const fetcher = async (url, opt) => {
-  if (!url || !opt) return;
+  if (!url) return;
   if (typeof url !== "string") return;
   const res = await fetch(url, opt);
   const json = await res.json();

--- a/client/src/pages/KingsMessagePage.js
+++ b/client/src/pages/KingsMessagePage.js
@@ -1,10 +1,38 @@
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import shallow from "zustand/shallow";
 import API from "../api";
 import { H2 } from "../components/styled";
-import { useLangModeStore } from "../store";
+import useAdminOnly from "../hooks/useAdminOnly";
+import { useLangModeStore, useLoggedInStore, useMessageStore } from "../store";
 import styles from "../styles/pages/kingsMessage.module.scss";
 
+let timeoutId = null;
+const ErrMsg = {
+  inputError: {
+    $KO: "유효하지 않은 입력값입니다.",
+    $EN: "Invalid inputs have been caught.",
+  },
+};
+
 const KingsMessagePage = () => {
+  const { loggedIn } = useLoggedInStore((state) => ({
+    loggedIn: state.loggedIn,
+  }));
+  useAdminOnly(loggedIn);
+  const { message, addMessage, resetMessage } = useMessageStore(
+    (state) => ({
+      message: state.message,
+      addMessage: state.addMessage,
+      resetMessage: state.resetMessage,
+    }),
+    shallow
+  );
+  useEffect(() => {
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  });
   const navigate = useNavigate();
   const { langMode } = useLangModeStore((state) => ({
     langMode: state.langMode,
@@ -14,9 +42,15 @@ const KingsMessagePage = () => {
     const {
       kingsMessage: { value },
     } = event.target;
-    value.length < 4 || typeof value !== "string"
-      ? console.log("invalid")
-      : console.log(value);
+    if (value.length < 4 || typeof value !== "string") {
+      const $OptMessage =
+        langMode === "en" ? ErrMsg.inputError.$EN : ErrMsg.inputError.$KO;
+      addMessage($OptMessage);
+      timeoutId = setTimeout(() => {
+        resetMessage();
+      }, 3000);
+      return;
+    }
     const fetchOpt = {
       method: "POST",
       headers: {
@@ -25,11 +59,12 @@ const KingsMessagePage = () => {
       body: JSON.stringify({ kingsMessage: value }),
     };
     const { success } = await API.createKingsMessage(fetchOpt);
-    console.log(success);
+    if (!success) return;
     navigate("/");
   };
   return (
     <section>
+      {!message.length ? null : <p className="message_box">{message}</p>}
       <H2>
         {langMode === "en" ? "Change King's Message" : "국왕 메세지 수정"}
       </H2>

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -1,11 +1,8 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import API from "../api";
 import Footer from "../components/Footer";
-import {
-  useKingsMessageStore,
-  useLangModeStore,
-  useLoggedInStore,
-} from "../store";
+import { useLangModeStore, useLoggedInStore } from "../store";
 import styles from "../styles/pages/home.module.scss";
 
 const HomePage = () => {
@@ -15,40 +12,44 @@ const HomePage = () => {
   const { langMode } = useLangModeStore((state) => ({
     langMode: state.langMode,
   }));
-  const [kingsMessage, setKingsMessage] = useState("야도가 미래다");
+  const [kingsMessage, setKingsMessage] = useState("");
   const navigate = useNavigate();
   const onClickKingsEmoji = () => {
     if (!loggedIn) return;
     navigate("/kings-message");
   };
 
-  useEffect ( () => {
-    fetch('http://localhost:8080/api/readKingsMessage')
-      .then(res => {
-        console.log('done');
-        return res.json()
-      })
-      .then(res => {
-        console.log(res[0].kingsMessage);
-        setKingsMessage(res[0].kingsMessage);
-      })
-  }, [])
+  useEffect(() => {
+    const getKingsMessage = async () => {
+      const result = await API.readKingsMessage();
+      const { success, kingsMessage } = result;
+      if (!success) return;
+      if (success && kingsMessage && typeof kingsMessage === "string") {
+        return setKingsMessage(kingsMessage);
+      }
+      return;
+    };
+    getKingsMessage();
+  }, []);
   return (
     <section>
       <div style={{ minHeight: "70vh" }}>
-        <div className={styles.kings_message}>
-          <p className={styles.kings_message__container}>
-            <span
-              onClick={onClickKingsEmoji}
-              className={`${styles.kings_message__emoji} ${
-                loggedIn ? styles.admin : ""
-              }`}
-            >
-              👸🏻
-            </span>
-            <span className={styles.kings_message__txt}>{kingsMessage}</span>
-          </p>
-        </div>
+        {kingsMessage ? (
+          <div className={styles.kings_message}>
+            <p className={styles.kings_message__container}>
+              <span
+                onClick={onClickKingsEmoji}
+                className={`${styles.kings_message__emoji} ${
+                  loggedIn ? styles.admin : ""
+                }`}
+              >
+                👸🏻
+              </span>
+
+              <span className={styles.kings_message__txt}>{kingsMessage}</span>
+            </p>
+          </div>
+        ) : null}
         <div
           style={{
             marginTop: "15px",

--- a/server/src/controller.js
+++ b/server/src/controller.js
@@ -6,8 +6,7 @@ mysql.connect();
 module.exports = {
   needs: () => upload,
 
-  main : {
-
+  main: {
     test: (req, res) => {
       res.json({ content: "now connected with server" });
     },
@@ -44,11 +43,9 @@ module.exports = {
 
       console.log(" userid : " + req.body.information.userid);
     },
-
   },
 
   api: {
-
     login: (req, res) => {
       const { password } = req.body;
       try {
@@ -67,37 +64,38 @@ module.exports = {
       }
     },
 
-    kingsMessage : (req,res) => {
+    kingsMessage: (req, res) => {
       const { kingsMessage } = req.body;
-      mysql.query("INSERT INTO rok_supporter.KingMsg (kingsMessage) VALUE ('"+kingsMessage+"');", (err, result) => {
-        if(!err) {
-          console.log("new Message : " + kingsMessage);
-          return res
-            .status(200)
-            .json({success : true});
-        } else {
-          console.log(err);
-          return res
-            .status(400)
-            .json({success : false});
+      mysql.query(
+        "INSERT INTO rok_supporter.KingMsg (kingsMessage) VALUE ('" +
+          kingsMessage +
+          "');",
+        (err, result) => {
+          if (!err) {
+            console.log("new Message : " + kingsMessage);
+            return res.status(200).json({ success: true });
+          } else {
+            console.log(err);
+            return res.status(400).json({ success: false });
+          }
         }
-      })
+      );
     },
 
-    readKingsMessage : (req,res) => {
-      mysql.query("SELECT kingsMessage FROM rok_supporter.KingMsg ORDER BY id DESC LIMIT 1;", (err, result) => {
-        if(!err) {
-          console.log(result[0].kingsMessage);
-          return res
-            .status(200)
-            .json(result);
-        } else {
-          console.log(err);
-          return res
-            .status(400)
-            .json({message : false});
+    readKingsMessage: (req, res) => {
+      mysql.query(
+        "SELECT kingsMessage FROM rok_supporter.KingMsg ORDER BY id DESC LIMIT 1;",
+        (err, result) => {
+          if (!err) {
+            const kingsMessage = result[0].kingsMessage;
+            console.log(kingsMessage);
+            return res.status(200).json({ kingsMessage });
+          } else {
+            console.log(err);
+            return res.status(400).json({ message: false });
+          }
         }
-      })
-    }
+      );
+    },
   },
 };


### PR DESCRIPTION
1) getKingsMessage를 API.js에서 처리하도록 최적화 및 리팩토링
2) admin loggedIn인 경우에만 kingsmessage 페이지 라우팅 가능하도록 adminOnly를 해당 페이지에 추가
3) kingsmessage 페이지에서 invalid input이 입력된 경우 클라이언트 메시지 처리
