### PR TITLE
save commanders data to zustand store not to repeat fetching

### DIFF
--- a/client/src/components/CommandersList.js
+++ b/client/src/components/CommandersList.js
@@ -15,7 +15,7 @@ const CommandersList = ({ commander }) => {
         <Link to={`/commanders/${cmd.id}`}>
           <div className={styles.img_container}>
             <img src={`${cmd.cmdSrc}`} alt={`${cmd.cmdName}`} />
-            <p>{cmd.cmdName}</p>
+            <p>{String(cmd.cmdName).split("_")[0]}</p>
           </div>
         </Link>
       ) : null}

--- a/client/src/pages/Commanders/CommanderPage.js
+++ b/client/src/pages/Commanders/CommanderPage.js
@@ -23,7 +23,11 @@ const CommanderPage = () => {
   }, [id]);
   return (
     <section>
-      {!commander ? <H1>Loading...</H1> : <H1>{commander.cmdName}</H1>}
+      {!commander ? (
+        <H1>Loading...</H1>
+      ) : (
+        <H1>{String(commander.cmdName).split("_").join(" ").toUpperCase()}</H1>
+      )}
     </section>
   );
 };

--- a/client/src/pages/Commanders/index.js
+++ b/client/src/pages/Commanders/index.js
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import shallow from "zustand/shallow";
 import API from "../../api";
 import CommandersList from "../../components/CommandersList";
 import { H2 } from "../../components/styled";
+import { useLoadedCommandersStore } from "../../store";
 import styles from "../../styles/pages/commanders.module.scss";
 
 const troopTypes = {
@@ -10,17 +12,30 @@ const troopTypes = {
   $CAV: "cavalry",
 };
 const CommandersPage = () => {
+  const { loadedCommanders, loadCommanders } = useLoadedCommandersStore(
+    (state) => ({
+      loadedCommanders: state.loadedCommanders,
+      loadCommanders: state.loadCommanders,
+    }),
+    shallow
+  );
   const [commanders, setCommanders] = useState([]);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
     const getAllCommanders = async () => {
+      if (loadedCommanders.length) {
+        setCommanders(loadedCommanders);
+        setLoading(false);
+        return;
+      }
       const { json, success } = await API.readAllCommanders();
       if (!success) return;
       setCommanders(json);
+      loadCommanders(json);
       setLoading(false);
     };
     getAllCommanders();
-  }, []);
+  }, [loadedCommanders, loadCommanders]);
   const [troopType, setTroopType] = useState(troopTypes.$ARC);
   return (
     <section>

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -61,3 +61,11 @@ export const useLoggedInStore = create((set) => ({
       };
     }),
 }));
+
+export const useLoadedCommandersStore = create((set) => ({
+  loadedCommanders: [],
+  loadCommanders: (arr) =>
+    set(() => ({
+      loadedCommanders: [...arr],
+    })),
+}));


### PR DESCRIPTION
commanders/index 페이지에서 commanders 데이터를 fetch할 때 zustand store(useLoadedCommandersStore)에도 저장하여 동일 라우터에서 같은 fetch를 반복하지 않고 store에 저장된 정보를 불러오도록 변경